### PR TITLE
update the deprecated ingress resource

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: "nginx"
-version: 1.2.0
+version: 1.2.1
 appVersion: "latest"
 description: "A simple nginx deployment which serves a static page"
 maintainers:

--- a/charts/nginx/templates/service.yaml
+++ b/charts/nginx/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
     instance: {{ .Values.Instance | quote }}
 ---
 {{ if .Values.Ingress.Enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "nginx.fullname" . }}
@@ -37,6 +37,9 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ template "nginx.fullname" . }}
-          servicePort: 80
+          service:
+            name: {{ template "nginx.fullname" . }}
+            port:
+              number: 80
+        pathType: ImplementationSpecific
 {{ end }}


### PR DESCRIPTION
extensions/v1beta1 is deprecated.  Update to use networking.k8s.io/v1 for the ingress.