### PR TITLE
Change image from karlnewell to globalnoc

### DIFF
--- a/charts/grnoc-telegraf/Chart.yaml
+++ b/charts/grnoc-telegraf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: grnoc-telegraf
-version: 0.7.0
-appVersion: 1.17.0
+version: 0.8.0
+appVersion: 2.0.3
 description: "Deploys an SNMP monitoring service and pushes metrics to a GRNOC TSDS using Telegraf."

--- a/charts/grnoc-telegraf/README.md
+++ b/charts/grnoc-telegraf/README.md
@@ -2,7 +2,7 @@
 
 Application Name (in catalog): `grnoc-telegraf`
 
-Application Version: `0.7.0`
+Application Version: `0.8.0`
 
 
 ## Description

--- a/charts/grnoc-telegraf/templates/deployment.yaml
+++ b/charts/grnoc-telegraf/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: telegraf
-          image: karlnewell/tsds-telegraf
+          image: ghcr.io/globalnoc/tsds-telegraf
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /etc/setup/


### PR DESCRIPTION
Closes #67 

Changed image from deprecated karlnewell to globalnoc. This should fix the issue of telegraf not installing on clusters because the image is wrong. 