### PR TITLE
Faucet: change StorageClass to storageClassName in values.yaml

### DIFF
--- a/charts/faucet/values.yaml
+++ b/charts/faucet/values.yaml
@@ -6,7 +6,7 @@
 Instance: global
 
 # StorageClass for logs (default nfs-client for minislate)
-StorageClass: nfs-client
+storageClassName: nfs-client
 
 # Configuration data for faucet this is faucet.yaml
 Configuration: |-


### PR DESCRIPTION
Closes #80 

Changed `StorageClass` to `storageClassName` in values.yaml for Faucet because it was believed that `StorageClass` was incorrect.  